### PR TITLE
Setting up the mqtt broker and database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore Mosquitto password files
+mosquitto_passwd
+*.passwd

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore Mosquitto password files
 mosquitto_passwd
 *.passwd
+init-db.sql

--- a/ControlServer/.gitignore
+++ b/ControlServer/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# config
+config.yml

--- a/ControlServer/.gitignore
+++ b/ControlServer/.gitignore
@@ -1,0 +1,125 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+*.egg-info/
+.installed.cfg
+*.egg
+dist/
+build/
+*.whl
+
+# Poetry specific
+poetry.lock
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+docs/_static/
+docs/_templates/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.env.*
+.venv
+.venv.*
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyderworkspace
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/ControlServer/DOCKERFILE
+++ b/ControlServer/DOCKERFILE
@@ -1,0 +1,32 @@
+# Stage 1: Build
+FROM python:3.9-slim as builder
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the pyproject.toml and poetry.lock files to the container
+COPY pyproject.toml poetry.lock ./
+
+# Install Poetry
+RUN pip install poetry
+
+# Install the dependencies
+RUN poetry config virtualenvs.create false && poetry install --no-dev --no-root
+
+# Copy the rest of the application code to the container
+COPY . .
+
+# Stage 2: Final
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy only the necessary files from the builder stage
+COPY --from=builder /app /app
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Run the application
+CMD ["python", "server.py"]

--- a/ControlServer/config.yml.template
+++ b/ControlServer/config.yml.template
@@ -1,0 +1,30 @@
+# Configuration file for ControlServer
+
+mqtt:
+    broker: mqtt.example.com
+    port: 1883
+    client_id: your_client_id
+    topic: your/topic
+    qos: 1
+    keep_alive: 60
+    clean_session: true
+    username: control_server
+    password: your_mqtt_password
+
+database:
+    host: db.example.com
+    port: 5432
+    name: smart_mailbox
+    user: control_server
+    password: your_database_password
+
+email:
+    smtp_server: smtp.example.com
+    port: 587
+    username: your_email_username
+    password: your_email_password
+    from_address: no-reply@example.com
+
+logging:
+    level: INFO
+    file: /var/log/controlserver.log

--- a/ControlServer/pyproject.toml
+++ b/ControlServer/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "controlserver"
+version = "0.1.0"
+description = ""
+authors = ["Nils Baxheinrich <nils@nbax.de>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+paho-mqtt = "^2.1.0"
+sqlalchemy = "^2.0.36"
+psycopg2-binary = "^2.9.10"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2024 Elina Baisariev, Sophie Hartmann, Nils Baxheinrich
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License

--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,3 @@
+# Smart Mailbox
+
+TODO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
     volumes:
       - mqtt_data:/mosquitto/data
       - mqtt_log:/mosquitto/log
+      - ./mosquitto/config:/mosquitto/config
+    environment:
+      - MOSQUITTO_USERNAME=your_username
+      - MOSQUITTO_PASSWORD=your_password
 
 volumes:
   timescaledb_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,26 +5,25 @@ services:
     image: timescale/timescaledb:latest-pg14
     container_name: timescaledb
     environment:
-      POSTGRES_USER: smart_mailbox
-      POSTGRES_PASSWORD: smart_mailbox
       POSTGRES_DB: smart_mailbox
     ports:
-      - "5432:5432"
+    - "5432:5432"
     volumes:
-      - timescaledb_data:/var/lib/postgresql/data
+    - timescaledb_data:/var/lib/postgresql/data
+    - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
 
   mqtt:
     image: eclipse-mosquitto:latest
     container_name: mqtt
     ports:
-      - "1883:1883"
+    - "1883:1883"
     volumes:
-      - mqtt_data:/mosquitto/data
-      - mqtt_log:/mosquitto/log
-      - ./mosquitto/config:/mosquitto/config
+    - mqtt_data:/mosquitto/data
+    - mqtt_log:/mosquitto/log
+    - ./mosquitto/config:/mosquitto/config
     environment:
-      - MOSQUITTO_USERNAME=your_username
-      - MOSQUITTO_PASSWORD=your_password
+    - MOSQUITTO_USERNAME=${MOSQUITTO_USERNAME}
+    - MOSQUITTO_PASSWORD=${MOSQUITTO_PASSWORD}
 
 volumes:
   timescaledb_data:

--- a/mosquitto/config/mosquitto.conf
+++ b/mosquitto/config/mosquitto.conf
@@ -1,0 +1,25 @@
+# Mosquitto configuration file
+
+# Listener settings
+listener 1883
+protocol mqtt
+
+# Allow anonymous connections
+allow_anonymous true
+
+# Persistence settings
+persistence true
+persistence_location /var/lib/mosquitto/
+
+# Logging settings
+log_dest file /var/log/mosquitto/mosquitto.log
+log_type error
+log_type warning
+log_type notice
+log_type information
+
+# Security settings
+password_file /etc/mosquitto/mosquitto_passwd.passwd
+
+# Include additional configuration files
+include_dir /etc/mosquitto/conf.d

--- a/mosquitto/config/mosquitto_passwd.passwd.template
+++ b/mosquitto/config/mosquitto_passwd.passwd.template
@@ -1,0 +1,5 @@
+# This is a template for the Mosquitto password file.
+# The format is: username:$7$101$salt$hash
+# Replace {{username}}, {{salt}}, and {{hash}} with actual values.
+
+your_username:$7$101$random_salt$random_hash

--- a/timescale/init-db.sql.template
+++ b/timescale/init-db.sql.template
@@ -1,0 +1,6 @@
+CREATE USER esp WITH PASSWORD 'your_password';
+CREATE USER control_server WITH PASSWORD 'your_password';
+CREATE USER web_server WITH PASSWORD 'your_password';
+GRANT ALL PRIVILEGES ON DATABASE smart_mailbox TO esp;
+GRANT ALL PRIVILEGES ON DATABASE smart_mailbox TO control_server;
+GRANT ALL PRIVILEGES ON DATABASE smart_mailbox TO web_server;


### PR DESCRIPTION
This pull request includes several important changes to the `ControlServer` project, focusing on configuration, containerization, and documentation. The most notable changes are the addition of a `.gitignore` file, a multi-stage Dockerfile, a configuration template, project metadata, and a license file.

Configuration and Environment Setup:
* Added `.gitignore` file to exclude various build, test, and environment files (`ControlServer/.gitignore`).
* Introduced a configuration template for MQTT, database, email, and logging settings (`ControlServer/config.yml.template`).

Containerization:
* Created a multi-stage Dockerfile to build and run the application using Poetry for dependency management (`ControlServer/DOCKERFILE`).
* Added a `docker-compose.yml` with the mosquitto mqtt broker and a timescale db for easy use.

Other Changes:
* Added a placeholder README file (`README.MD`).